### PR TITLE
Add customizable node support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 pip install dash dash-bootstrap-components flask plotly requests pandas flowfunc numpy pybit python-binance
 ```
 
+Дополнительные возможности кастомизации узлов доступны через модуль
+`extended_flowfunc`, который расширяет библиотеку `flowfunc`.
+
 **Запуск**
 ```
 python main.py

--- a/extended_flowfunc/__init__.py
+++ b/extended_flowfunc/__init__.py
@@ -1,0 +1,17 @@
+"""Extended version of the flowfunc package with additional customization options."""
+
+from flowfunc import Flowfunc
+from flowfunc.jobrunner import JobRunner
+from flowfunc.types import *  # re-export standard types
+
+from .config import Config, node_config
+from .models import Node, Port
+
+__all__ = [
+    "Flowfunc",
+    "JobRunner",
+    "Config",
+    "node_config",
+    "Node",
+    "Port",
+]

--- a/extended_flowfunc/config.py
+++ b/extended_flowfunc/config.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+from typing import Any, Callable, List, Optional
+
+import flowfunc.config as base
+from flowfunc.models import Port
+from .models import Node
+
+
+def node_config(**kwargs: Any):
+    """Decorator to attach custom configuration to node functions."""
+
+    def decorator(func: Callable) -> Callable:
+        setattr(func, "_node_custom_config", kwargs)
+        return func
+
+    return decorator
+
+
+class Config(base.Config):
+    """Extended Config supporting custom node attributes."""
+
+    @classmethod
+    def from_function_list(
+        cls,
+        function_list: List[Callable],
+        extra_nodes: Optional[List[Node]] = None,
+        extra_ports: Optional[List[Port]] = None,
+    ) -> "Config":
+        nodes: List[Node] = []
+        for func in function_list:
+            base_node = base.process_node(func)
+            node_data = base_node.model_dump()
+            node_data.update(getattr(func, "_node_custom_config", {}))
+            node = Node(**node_data, method=base_node.method)
+            nodes.append(node)
+
+        extra_nodes = extra_nodes or []
+        extra_ports = extra_ports or []
+        ports = list(set(extra_ports + base.ports_from_nodes(nodes)))
+        nodes = nodes + extra_nodes
+        return cls(nodes, ports)

--- a/extended_flowfunc/models.py
+++ b/extended_flowfunc/models.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+from typing import Any
+from pydantic import Field
+import flowfunc.models as fm
+
+class Node(fm.Node):
+    """Extended Node model supporting additional customization options."""
+
+    icon: str | None = None
+    style: dict[str, Any] | None = None
+    extra: dict[str, Any] | None = Field(default=None, description="Arbitrary node settings")
+
+class Port(fm.Port):
+    """Extended Port model with optional styling."""
+
+    style: dict[str, Any] | None = None

--- a/modules/charts.py
+++ b/modules/charts.py
@@ -2,8 +2,8 @@ import dash
 from dash import Dash, html, dcc, Input, Output, callback, State
 import dash_bootstrap_components as dbc
 import plotly.graph_objs as go
-import flowfunc
-from flowfunc.config import Config
+import extended_flowfunc as flowfunc
+from extended_flowfunc import Config
 from flowfunc.jobrunner import JobRunner
 from modules.nodeeditor.nodes_logic.nodes import (
     all_functions,

--- a/modules/nodeeditor/nodes.py
+++ b/modules/nodeeditor/nodes.py
@@ -1,8 +1,8 @@
-import flowfunc
+import extended_flowfunc as flowfunc
 import time
 import os
 from dash import html, dcc
-from flowfunc.config import Config 
+from extended_flowfunc import Config
 from flowfunc.jobrunner import JobRunner
 import dash
 from dash.dependencies import Input, Output, State
@@ -11,11 +11,12 @@ import dash_bootstrap_components as dbc
 import json
 import base64
 from flask import Blueprint, request,jsonify
-from flowfunc.models import OutNode, Node, Port
+from flowfunc.models import OutNode
+from extended_flowfunc.models import Node, Port
 from modules.nodeeditor.nodes_logic.nodes import all_functions
 from dash import Dash, html, dcc, Input, Output, callback, State
 from typing import Any
-from flowfunc.models import Node, Port
+from extended_flowfunc.models import Node, Port
 
 
 


### PR DESCRIPTION
## Summary
- extend `flowfunc` via new `extended_flowfunc` module
- allow custom node parameters with decorator and new fields
- switch app code to use `extended_flowfunc`
- document the new module

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- manual execution of extended_flowfunc to ensure decorator works

------
https://chatgpt.com/codex/tasks/task_e_684515ed8f688322a0649f44aa59897c